### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/dist/runtime/components/lib/OpenApiDarkModeToggle.vue
+++ b/dist/runtime/components/lib/OpenApiDarkModeToggle.vue
@@ -20,7 +20,7 @@ export default {
     }
   },
   mounted() {
-    if(process.client) {
+    if(import.meta.client) {
       this.isDarkMode = localStorage.getItem('isDarkMode') === 'true'
       if(this.isDarkMode) document.querySelector('html').classList.add('dark')
     }

--- a/dist/runtime/components/lib/SearchBlock.vue
+++ b/dist/runtime/components/lib/SearchBlock.vue
@@ -98,7 +98,7 @@ export default {
     },
   },
   mounted() {
-    if(process.client) {
+    if(import.meta.client) {
       this.$openapidocBus.$on('toggleSearchDoc', this.toggleSearch);
 
       this.search = (this.$route.query?.query ?? '').toString();

--- a/dist/runtime/layout/OpenApiLayoutNuxt3.vue
+++ b/dist/runtime/layout/OpenApiLayoutNuxt3.vue
@@ -97,7 +97,7 @@ function handleResize () {
 }
 
 onMounted(() => {
-  if (process.client) {
+  if (import.meta.client) {
     isMobile.value = window.innerWidth < 1110;
     isMenuOpen.value = window.innerWidth >= 1110;
     window.addEventListener('resize', handleResize)

--- a/dist/runtime/plugins/plugin3.mjs
+++ b/dist/runtime/plugins/plugin3.mjs
@@ -19,7 +19,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const i18nLinker = nuxtApp.$i18n ? new I18nLinker(nuxtApp.$i18n) : null;
   const openapidoc = new OpenApiPlugin(i18nLinker);
   const openapidocRef = new OpenApiRefPlugin(i18nLinker);
-  if (process.server) {
+  if (import.meta.server) {
     nuxtApp.payload.openapidocRefDefinitions = openapidocRef.definitions;
     nuxtApp.payload.openapidocRefComponents = openapidocRef.components;
   } else if (nuxtApp.payload) {

--- a/dist/runtime/templates/OpenApiTemplateNuxt3.vue
+++ b/dist/runtime/templates/OpenApiTemplateNuxt3.vue
@@ -237,7 +237,7 @@ function downloadJson() {
 }
 
 onMounted(() => {
-  if(process.client) {
+  if(import.meta.client) {
     $openapidocBus.$on('downloadJsonDoc', downloadJson);
     $openapidocBus.$on('changeServer', onChangeServer);
     setScrollPosition();

--- a/src/runtime/components/lib/OpenApiDarkModeToggle.vue
+++ b/src/runtime/components/lib/OpenApiDarkModeToggle.vue
@@ -21,7 +21,7 @@ export default {
     }
   },
   mounted() {
-    if(process.client) {
+    if(import.meta.client) {
       this.isDarkMode = localStorage.getItem('isDarkMode') === 'true'
       if(this.isDarkMode) document.querySelector('html').classList.add('dark')
     }

--- a/src/runtime/components/lib/SearchBlock.vue
+++ b/src/runtime/components/lib/SearchBlock.vue
@@ -98,7 +98,7 @@ export default {
     },
   },
   mounted() {
-    if(process.client) {
+    if(import.meta.client) {
       this.$openapidocBus.$on('toggleSearchDoc', this.toggleSearch);
 
       this.search = (this.$route.query?.query ?? '').toString();

--- a/src/runtime/layout/OpenApiLayoutNuxt3.vue
+++ b/src/runtime/layout/OpenApiLayoutNuxt3.vue
@@ -97,7 +97,7 @@ function handleResize () {
 }
 
 onMounted(() => {
-  if (process.client) {
+  if (import.meta.client) {
     isMobile.value = window.innerWidth < 1110;
     isMenuOpen.value = window.innerWidth >= 1110;
     window.addEventListener('resize', handleResize)

--- a/src/runtime/plugins/plugin3.ts
+++ b/src/runtime/plugins/plugin3.ts
@@ -25,7 +25,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const openapidoc = new OpenApiPlugin(i18nLinker)
   const openapidocRef = new OpenApiRefPlugin(i18nLinker)
 
-  if (process.server) {
+  if (import.meta.server) {
     nuxtApp.payload.openapidocRefDefinitions = openapidocRef.definitions;
     nuxtApp.payload.openapidocRefComponents = openapidocRef.components;
   } else if (nuxtApp.payload) {

--- a/src/runtime/templates/OpenApiTemplateNuxt3.vue
+++ b/src/runtime/templates/OpenApiTemplateNuxt3.vue
@@ -237,7 +237,7 @@ function downloadJson() {
 }
 
 onMounted(() => {
-  if(process.client) {
+  if(import.meta.client) {
     $openapidocBus.$on('downloadJsonDoc', downloadJson);
     $openapidocBus.$on('changeServer', onChangeServer);
     setScrollPosition();


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)