### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,7 @@ export default defineConfig({
 1. Add `nuxt-openapi-docs-module` dependency to your project
 
 ```bash
-# Using yarn
-yarn add --dev nuxt-openapi-docs-module
-
-# Using npm
-npm install --save-dev nuxt-openapi-docs-module
+npx nuxi@latest module add nuxt-openapi-docs-module
 ```
 
 2. Add `nuxt-openapi-docs-module` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
