### PR TITLE
fix: use `lodash.template` directly to compile template

### DIFF
--- a/dist/module.mjs
+++ b/dist/module.mjs
@@ -1,4 +1,3 @@
-import { template } from 'lodash-es'
 import { defineNuxtModule, createResolver, addComponentsDir, addTemplate, extendPages, addLayout, addPlugin } from '@nuxt/kit';
 import { extname, join, basename, resolve } from 'path';
 import { readFileSync, promises, existsSync, mkdirSync, writeFileSync } from 'node:fs';
@@ -438,7 +437,7 @@ const module = defineNuxtModule({
       addLayout({
         getContents({ options }) {
           const contents = readFileSync(resolver.resolve(`./runtime/layout/OpenApiLayoutNuxt3.vue`), 'utf-8')
-          return template(contents)({ options })
+          return _.template(contents)({ options })
         },
         filename: `openapi/apidocs.layout.${item.filename}.vue`,
         write: true,

--- a/dist/module.mjs
+++ b/dist/module.mjs
@@ -1,6 +1,7 @@
+import { template } from 'lodash-es'
 import { defineNuxtModule, createResolver, addComponentsDir, addTemplate, extendPages, addLayout, addPlugin } from '@nuxt/kit';
 import { extname, join, basename, resolve } from 'path';
-import { promises, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { readFileSync, promises, existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import _ from 'lodash';
 import { kebabCase } from 'scule';
 import fs from 'fs';
@@ -435,7 +436,10 @@ const module = defineNuxtModule({
     }
     for (let item of docs) {
       addLayout({
-        src: resolver.resolve(`./runtime/layout/OpenApiLayoutNuxt3.vue`),
+        getContents({ options }) {
+          const contents = readFileSync(resolver.resolve(`./runtime/layout/OpenApiLayoutNuxt3.vue`), 'utf-8')
+          return template(contents)({ options })
+        },
         filename: `openapi/apidocs.layout.${item.filename}.vue`,
         write: true,
         options: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { template } from 'lodash-es'
 import {
   addPlugin,
   defineNuxtModule,
@@ -8,7 +9,7 @@ import {
   addTemplate,
 } from '@nuxt/kit'
 import {resolve, extname, basename, join} from "path";
-import {promises, existsSync, writeFileSync, mkdirSync} from "node:fs";
+import { readFileSync,promises, existsSync, writeFileSync, mkdirSync} from "node:fs";
 import _ from "lodash";
 import type {Resolver} from '@nuxt/kit'
 import {kebabCase} from "scule";
@@ -185,7 +186,10 @@ export default defineNuxtModule<ModuleOptions>({
 
     for (let item of docs) {
       addLayout({
-        src: resolver.resolve(`./runtime/layout/OpenApiLayoutNuxt3.vue`),
+        getContents({ options }) {
+          const contents = readFileSync(resolver.resolve(`./runtime/layout/OpenApiLayoutNuxt3.vue`), 'utf-8')
+          return template(contents)({ options })
+        },
         filename: `openapi/apidocs.layout.${item.filename}.vue`,
         write: true,
         options: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,3 @@
-import { template } from 'lodash-es'
 import {
   addPlugin,
   defineNuxtModule,
@@ -9,7 +8,7 @@ import {
   addTemplate,
 } from '@nuxt/kit'
 import {resolve, extname, basename, join} from "path";
-import { readFileSync,promises, existsSync, writeFileSync, mkdirSync} from "node:fs";
+import {readFileSync, promises, existsSync, writeFileSync, mkdirSync} from "node:fs";
 import _ from "lodash";
 import type {Resolver} from '@nuxt/kit'
 import {kebabCase} from "scule";
@@ -188,7 +187,7 @@ export default defineNuxtModule<ModuleOptions>({
       addLayout({
         getContents({ options }) {
           const contents = readFileSync(resolver.resolve(`./runtime/layout/OpenApiLayoutNuxt3.vue`), 'utf-8')
-          return template(contents)({ options })
+          return _.template(contents)({ options })
         },
         filename: `openapi/apidocs.layout.${item.filename}.vue`,
         write: true,


### PR DESCRIPTION
We are going to be removing support for [compiling templates from disk using `lodash.template`](https://github.com/nuxt/nuxt/issues/25332) in Nuxt v4. This is a PR to move lodash usage directly into the module to avoid breaking it on Nuxt 4.

It would also be possible to avoid using it entirely, which I would _strongly_ recommend, either:
* using a custom function to handle the replacement, such as in https://github.com/nuxt-modules/color-mode/pull/240
* or moving the string interpolation logic directly into `getContents`

I note that there are a couple of places where you generate the template and consume it later, so it's possible this fix needs to be applied to more `addTemplate` calls than just the one I've included in the PR. But I hope it's a good start (and advance warning of the change!).